### PR TITLE
Psgroove dev

### DIFF
--- a/firmware/usbstack/config.h
+++ b/firmware/usbstack/config.h
@@ -26,9 +26,9 @@
 //#define FIRMWARE_3_41
 
 /* 2. Define your Target payload reg/NUS/Dev/etc -= ONLY USE ONE! =- */
-#define Payload_Regular //if you don't know what the others are-- this is what you want!
+//#define Payload_Regular //if you don't know what the others are-- this is what you want!
 //#define Payload_NUS
-//#define Payload_Dev
+#define Payload_Dev
 //#define Payload_Dump_ELFS
 //#define Payload_Trace_ALL_SC
 //#define Payload_Trace_HVC

--- a/firmware/usbstack/config.h
+++ b/firmware/usbstack/config.h
@@ -15,7 +15,7 @@
 /* Define this macro if want to use the jig method */
 #define USE_JIG
 
-/* 1. Define your PS3 Firmware.*/
+/* 1. Define your PS3 Firmware. -= ONLY USE ONE! =-*/
 /* The firmware version supported gets defined in the Makefile */
 //#define FIRMWARE_2_76
 //#define FIRMWARE_3_01
@@ -25,8 +25,8 @@
 //#define FIRMWARE_3_40
 //#define FIRMWARE_3_41
 
-/* 2. Define your Target payload reg/NUS/Dev/etc */
-#define Payload_Regular
+/* 2. Define your Target payload reg/NUS/Dev/etc -= ONLY USE ONE! =- */
+#define Payload_Regular //if you don't know what the others are-- this is what you want!
 //#define Payload_NUS
 //#define Payload_Dev
 //#define Payload_Dump_ELFS

--- a/firmware/usbstack/config.h
+++ b/firmware/usbstack/config.h
@@ -1,0 +1,38 @@
+/*
+ * config.h -- PS3 Jailbreak payload : configuration file
+ *
+ * Copyright (C) Youness Alaoui (KaKaRoTo)
+ *
+ * This software is distributed under the terms of the GNU General Public
+ * License ("GPL") version 3, as published by the Free Software Foundation.
+ *
+ */
+
+#ifndef PL3_CONFIG_H
+#define PL3_CONFIG_H
+
+
+/* Define this macro if want to use the jig method */
+#define USE_JIG
+
+/* 1. Define your PS3 Firmware.*/
+/* The firmware version supported gets defined in the Makefile */
+//#define FIRMWARE_2_76
+//#define FIRMWARE_3_01
+//#define FIRMWARE_3_10
+#define FIRMWARE_3_15
+//#define FIRMWARE_3_21
+//#define FIRMWARE_3_40
+//#define FIRMWARE_3_41
+
+/* 2. Define your Target payload reg/NUS/Dev/etc */
+#define Payload_Regular
+//#define Payload_NUS
+//#define Payload_Dev
+//#define Payload_Dump_ELFS
+//#define Payload_Trace_ALL_SC
+//#define Payload_Trace_HVC
+//#define Payload_Trace_SC
+//#define Payload_Trace_VUART
+
+#endif /* PL3_CONFIG_H */

--- a/firmware/usbstack/psgrooveFWSelection.h
+++ b/firmware/usbstack/psgrooveFWSelection.h
@@ -1,0 +1,90 @@
+/*
+PSGroove header to configure payload selections
+*/
+
+#if defined (FIRMWARE_3_41) || defined (FIRMWARE_3_40)
+#       define RTOC_TABLE		0x80, 0x00, 0x00, 0x00, 0x00, 0x33, 0xe7, 0x20
+#elif defined (FIRMWARE_3_15) || defined (FIRMWARE_3_10)
+#       define RTOC_TABLE		0x80, 0x00, 0x00, 0x00, 0x00, 0x33, 0xda, 0x10
+#elif defined (FIRMWARE_3_01)
+#       define RTOC_TABLE		0x80, 0x00, 0x00, 0x00, 0x00, 0x32, 0x06, 0x40
+#elif defined (FIRMWARE_2_76)
+#       define RTOC_TABLE		0x80, 0x00, 0x00, 0x00, 0x00, 0x31, 0x3E, 0x70
+#elif defined (FIRMWARE_3_21)
+#       define RTOC_TABLE		0x80, 0x00, 0x00, 0x00, 0x00, 0x33, 0xda, 0x90
+#elif defined (FIRMWARE_3_30)
+#       define RTOC_TABLE		0x80, 0x00, 0x00, 0x00, 0x00, 0x33, 0xdb, 0xc0
+
+#else
+
+#error You must specify the target firmware. \
+   define a supported FIRMWARE_X_YZ in config.h and recompile.
+#endif 
+
+/* FIRMWARE_X_YZ */
+#ifdef USE_JIG
+       #define default_shellcode shellcode_egghunt
+       #define default_shellcode_macro shellcode_egghunt_macro
+
+#if defined (FIRMWARE_3_41)
+#       define default_payload default_payload_3_41
+#       define default_payload_macro default_payload_3_41_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xee, 0x70
+#elif defined (FIRMWARE_3_15)
+#       define default_payload default_payload_3_15
+#       define default_payload_macro default_payload_3_15_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x30
+#elif defined (FIRMWARE_3_10)
+#       define default_payload default_payload_3_10
+#       define default_payload_macro default_payload_3_10_macro
+#       define SHELLCODE_ADDR_BASE  0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x30
+#elif defined (FIRMWARE_3_01)
+#       define default_payload default_payload_3_01
+#       define default_payload_macro default_payload_3_01_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3B, 0xFB, 0xC8
+#elif defined (FIRMWARE_3_40)
+#       define default_payload default_payload_3_40
+#       define default_payload_macro default_payload_3_40_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xee, 0x70
+#elif defined (FIRMWARE_2_76)
+#       define default_payload default_payload_2_76
+#       define default_payload_macro default_payload_2_76_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3B, 0x1B, 0xC8
+#elif defined (FIRMWARE_3_21)
+#       define default_payload default_payload_3_21
+#       define default_payload_macro default_payload_3_21_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x30
+#elif defined (FIRMWARE_3_30)
+#       define default_payload default_payload_3_30
+#       define default_payload_macro default_payload_3_30_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x70
+
+#endif
+/* FIRMWARE_X_YZ */
+
+#define SHELLCODE_PAGE		0x80, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00
+#define SHELLCODE_DESTINATION	SHELLCODE_ADDR_BASE
+#define SHELLCODE_PTR 		SHELLCODE_ADDR_BASE + 0x08
+#define SHELLCODE_ADDRESS	SHELLCODE_ADDR_BASE + 0x18
+
+#define PORT1_NUM_CONFIGS	4
+
+#else 
+/* USE_JIG Not defined, dump LV2 rather than jailbreak.*/
+
+      #define default_shellcode shellcode_egghunt
+      #define default_shellcode_macro shellcode_egghunt_macro
+      #define default_payload dump_lv2
+      #define default_payload_macro dump_lv2_macro
+
+      #define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x4E, 0x00, 0x00
+
+      #define SHELLCODE_PAGE		SHELLCODE_ADDR_BASE
+      #define SHELLCODE_DESTINATION	SHELLCODE_ADDR_BASE + 0x20
+      #define SHELLCODE_PTR 		SHELLCODE_ADDR_BASE + 0x28
+      #define SHELLCODE_ADDRESS	SHELLCODE_ADDR_BASE + 0x38
+
+      #define PORT1_NUM_CONFIGS	100
+
+#endif
+ /* USE_JIG */

--- a/firmware/usbstack/psgrooveFWSelection.h
+++ b/firmware/usbstack/psgrooveFWSelection.h
@@ -26,39 +26,351 @@ PSGroove header to configure payload selections
        #define default_shellcode shellcode_egghunt
        #define default_shellcode_macro shellcode_egghunt_macro
 
-#if defined (FIRMWARE_3_41)
+//begin Regular Payload, if you don't know what the others are-- this is what you want!
+#if defined Payload_Regular
+#   if defined (FIRMWARE_3_41)
 #       define default_payload default_payload_3_41
 #       define default_payload_macro default_payload_3_41_macro
 #       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xee, 0x70
-#elif defined (FIRMWARE_3_15)
+#   elif defined (FIRMWARE_3_15)
 #       define default_payload default_payload_3_15
 #       define default_payload_macro default_payload_3_15_macro
 #       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x30
-#elif defined (FIRMWARE_3_10)
+#   elif defined (FIRMWARE_3_10)
 #       define default_payload default_payload_3_10
 #       define default_payload_macro default_payload_3_10_macro
 #       define SHELLCODE_ADDR_BASE  0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x30
-#elif defined (FIRMWARE_3_01)
+#   elif defined (FIRMWARE_3_01)
 #       define default_payload default_payload_3_01
 #       define default_payload_macro default_payload_3_01_macro
 #       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3B, 0xFB, 0xC8
-#elif defined (FIRMWARE_3_40)
+#   elif defined (FIRMWARE_3_40)
 #       define default_payload default_payload_3_40
 #       define default_payload_macro default_payload_3_40_macro
 #       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xee, 0x70
-#elif defined (FIRMWARE_2_76)
+#   elif defined (FIRMWARE_2_76)
 #       define default_payload default_payload_2_76
 #       define default_payload_macro default_payload_2_76_macro
 #       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3B, 0x1B, 0xC8
-#elif defined (FIRMWARE_3_21)
+#   elif defined (FIRMWARE_3_21)
 #       define default_payload default_payload_3_21
 #       define default_payload_macro default_payload_3_21_macro
 #       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x30
-#elif defined (FIRMWARE_3_30)
+#   elif defined (FIRMWARE_3_30)
 #       define default_payload default_payload_3_30
 #       define default_payload_macro default_payload_3_30_macro
 #       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x70
-
+#   endif
+// End Regular Payload
+//begin Dev Payload... as of the current PL3 this has more than just peek and poke. If you don't know what... you want Regular.
+#elif defined (Payload_Dev)
+#   if defined (FIRMWARE_3_41)
+#       include "pl3/payload_dev_3_41.h"
+#       define default_payload payload_dev_3_41
+#       define default_payload_macro payload_dev_3_41_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xee, 0x70
+#   elif defined (FIRMWARE_3_15)
+#       include "pl3/payload_dev_3_15.h"
+#       define default_payload payload_dev_3_15
+#       define default_payload_macro payload_dev_3_15_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x30
+#   elif defined (FIRMWARE_3_10)
+#       include "pl3/payload_dev_3_10.h"
+#       define default_payload payload_dev_3_10
+#       define default_payload_macro payload_dev_3_10_macro
+#       define SHELLCODE_ADDR_BASE  0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x30
+#   elif defined (FIRMWARE_3_01)
+#       include "pl3/payload_dev_3_01.h"
+#       define default_payload payload_dev_3_01
+#       define default_payload_macro payload_dev_3_01_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3B, 0xFB, 0xC8
+#   elif defined (FIRMWARE_3_40)
+#       include "pl3/payload_dev_3_40.h"
+#       define default_payload payload_dev_3_40
+#       define default_payload_macro payload_dev_3_40_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xee, 0x70
+#   elif defined (FIRMWARE_2_76)
+#       include "pl3/payload_dev_2_76.h"
+#       define default_payload payload_dev_2_76
+#       define default_payload_macro payload_dev_2_76_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3B, 0x1B, 0xC8
+#   elif defined (FIRMWARE_3_21)
+#       include "pl3/payload_dev_3_21.h"
+#       define default_payload payload_dev_3_21
+#       define default_payload_macro payload_dev_3_21_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x30
+#   elif defined (FIRMWARE_3_30)
+#       include "pl3/payload_dev_3_30.h"
+#       define default_payload payload_dev_3_30
+#       define default_payload_macro payload_dev_3_30_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x70
+#   endif
+//end Dev Payload
+//begin Payload_Trace_ALL_SC Payload... If you don't know what this is... you want Regular.
+#elif defined (Payload_Trace_ALL_SC)
+#   if defined (FIRMWARE_3_41)
+#       include "pl3/payload_trace_all_sc_calls_3_41.h"
+#       define default_payload payload_trace_all_sc_calls_3_41
+#       define default_payload_macro payload_trace_all_sc_calls_3_41_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xee, 0x70
+#   elif defined (FIRMWARE_3_15)
+#       include "pl3/payload_trace_all_sc_calls_3_15.h"
+#       define default_payload payload_trace_all_sc_calls_3_15
+#       define default_payload_macro payload_trace_all_sc_calls_3_15_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x30
+#   elif defined (FIRMWARE_3_10)
+#       include "pl3/payload_trace_all_sc_calls_3_10.h"
+#       define default_payload payload_trace_all_sc_calls_3_10
+#       define default_payload_macro payload_trace_all_sc_calls_3_10_macro
+#       define SHELLCODE_ADDR_BASE  0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x30
+#   elif defined (FIRMWARE_3_01)
+#       include "pl3/payload_trace_all_sc_calls_3_01.h"
+#       define default_payload payload_trace_all_sc_calls_3_01
+#       define default_payload_macro payload_trace_all_sc_calls_3_01_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3B, 0xFB, 0xC8
+#   elif defined (FIRMWARE_3_40)
+#       include "pl3/payload_trace_all_sc_calls_3_40.h"
+#       define default_payload payload_trace_all_sc_calls_3_40
+#       define default_payload_macro payload_trace_all_sc_calls_3_40_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xee, 0x70
+#   elif defined (FIRMWARE_2_76)
+#       include "pl3/payload_trace_all_sc_calls_2_76.h"
+#       define default_payload payload_trace_all_sc_calls_2_76
+#       define default_payload_macro payload_trace_all_sc_calls_2_76_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3B, 0x1B, 0xC8
+#   elif defined (FIRMWARE_3_21)
+#       include "pl3/payload_trace_all_sc_calls_3_21.h"
+#       define default_payload payload_trace_all_sc_calls_3_21
+#       define default_payload_macro payload_trace_all_sc_calls_3_21_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x30
+#   elif defined (FIRMWARE_3_30)
+#       include "pl3/payload_trace_all_sc_calls_3_30.h"
+#       define default_payload payload_trace_all_sc_calls_3_30
+#       define default_payload_macro payload_trace_all_sc_calls_3_30_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x70
+#   endif
+//end Payload_Trace_ALL_SC Payload
+//begin NUS Payload... If you don't know what this is... you want Regular.
+#elif defined (Payload_NUS)
+#   if defined (FIRMWARE_3_41)
+#       include "pl3/payload_no_unauth_syscall_3_41.h"
+#       define default_payload payload_no_unauth_syscall_3_41
+#       define default_payload_macro payload_no_unauth_syscall_3_41_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xee, 0x70
+#   elif defined (FIRMWARE_3_15)
+#       include "pl3/payload_no_unauth_syscall_3_15.h"
+#       define default_payload payload_no_unauth_syscall_3_15
+#       define default_payload_macro payload_no_unauth_syscall_3_15_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x30
+#   elif defined (FIRMWARE_3_10)
+#       include "pl3/payload_no_unauth_syscall_3_10.h"
+#       define default_payload payload_no_unauth_syscall_3_10
+#       define default_payload_macro payload_no_unauth_syscall_3_10_macro
+#       define SHELLCODE_ADDR_BASE  0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x30
+#   elif defined (FIRMWARE_3_01)
+#       include "pl3/payload_no_unauth_syscall_3_01.h"
+#       define default_payload payload_no_unauth_syscall_3_01
+#       define default_payload_macro payload_no_unauth_syscall_3_01_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3B, 0xFB, 0xC8
+#   elif defined (FIRMWARE_3_40)
+#       include "pl3/payload_no_unauth_syscall_3_40.h"
+#       define default_payload payload_no_unauth_syscall_3_40
+#       define default_payload_macro payload_no_unauth_syscall_3_40_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xee, 0x70
+#   elif defined (FIRMWARE_2_76)
+#       include "pl3/payload_no_unauth_syscall_2_76.h"
+#       define default_payload payload_no_unauth_syscall_2_76
+#       define default_payload_macro payload_no_unauth_syscall_2_76_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3B, 0x1B, 0xC8
+#   elif defined (FIRMWARE_3_21)
+#       include "pl3/payload_no_unauth_syscall_3_21.h"
+#       define default_payload payload_no_unauth_syscall_3_21
+#       define default_payload_macro payload_no_unauth_syscall_3_21_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x30
+#   elif defined (FIRMWARE_3_30)
+#       include "pl3/payload_no_unauth_syscall_3_30.h"
+#       define default_payload payload_no_unauth_syscall_3_30
+#       define default_payload_macro payload_no_unauth_syscall_3_30_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x70
+#   endif
+//end NUS Payload
+//begin Payload_Dump_ELFS Payload... If you don't know what this is... you want Regular.
+#elif defined (Payload_Dump_ELFS)
+#   if defined (FIRMWARE_3_41)
+#       include "pl3/payload_dump_elfs_3_41.h"
+#       define default_payload payload_dump_elfs_3_41
+#       define default_payload_macro payload_dump_elfs_3_41_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xee, 0x70
+#   elif defined (FIRMWARE_3_15)
+#       include "pl3/payload_dump_elfs_3_15.h"
+#       define default_payload payload_dump_elfs_3_15
+#       define default_payload_macro payload_dump_elfs_3_15_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x30
+#   elif defined (FIRMWARE_3_10)
+#       include "pl3/payload_dump_elfs_3_10.h"
+#       define default_payload payload_dump_elfs_3_10
+#       define default_payload_macro payload_dump_elfs_3_10_macro
+#       define SHELLCODE_ADDR_BASE  0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x30
+#   elif defined (FIRMWARE_3_01)
+#       include "pl3/payload_dump_elfs_3_01.h"
+#       define default_payload payload_dump_elfs_3_01
+#       define default_payload_macro payload_dump_elfs_3_01_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3B, 0xFB, 0xC8
+#   elif defined (FIRMWARE_3_40)
+#       include "pl3/payload_dump_elfs_3_40.h"
+#       define default_payload payload_dump_elfs_3_40
+#       define default_payload_macro payload_dump_elfs_3_40_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xee, 0x70
+#   elif defined (FIRMWARE_2_76)
+#       include "pl3/payload_dump_elfs_2_76.h"
+#       define default_payload payload_dump_elfs_2_76
+#       define default_payload_macro payload_dump_elfs_2_76_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3B, 0x1B, 0xC8
+#   elif defined (FIRMWARE_3_21)
+#       include "pl3/payload_dump_elfs_3_21.h"
+#       define default_payload payload_dump_elfs_3_21
+#       define default_payload_macro payload_dump_elfs_3_21_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x30
+#   elif defined (FIRMWARE_3_30)
+#       include "pl3/payload_dump_elfs_3_30.h"
+#       define default_payload payload_dump_elfs_3_30
+#       define default_payload_macro payload_dump_elfs_3_30_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x70
+#   endif
+//end Payload_Dump_ELFS Payload
+//begin Payload_Trace_HVC Payload... If you don't know what this is... you want Regular.
+#elif defined (Payload_Trace_HVC)
+#   if defined (FIRMWARE_3_41)
+#       include "pl3/payload_trace_hypercalls_3_41.h"
+#       define default_payload payload_trace_hypercalls_3_41
+#       define default_payload_macro payload_trace_hypercalls_3_41_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xee, 0x70
+#   elif defined (FIRMWARE_3_15)
+#       include "pl3/payload_trace_hypercalls_3_15.h"
+#       define default_payload payload_trace_hypercalls_3_15
+#       define default_payload_macro payload_trace_hypercalls_3_15_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x30
+#   elif defined (FIRMWARE_3_10)
+#       include "pl3/payload_trace_hypercalls_3_10.h"
+#       define default_payload payload_trace_hypercalls_3_10
+#       define default_payload_macro payload_trace_hypercalls_3_10_macro
+#       define SHELLCODE_ADDR_BASE  0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x30
+#   elif defined (FIRMWARE_3_01)
+#       include "pl3/payload_trace_hypercalls_3_01.h"
+#       define default_payload payload_trace_hypercalls_3_01
+#       define default_payload_macro payload_trace_hypercalls_3_01_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3B, 0xFB, 0xC8
+#   elif defined (FIRMWARE_3_40)
+#       include "pl3/payload_trace_hypercalls_3_40.h"
+#       define default_payload payload_trace_hypercalls_3_40
+#       define default_payload_macro payload_trace_hypercalls_3_40_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xee, 0x70
+#   elif defined (FIRMWARE_2_76)
+#       include "pl3/payload_trace_hypercalls_2_76.h"
+#       define default_payload payload_trace_hypercalls_2_76
+#       define default_payload_macro payload_trace_hypercalls_2_76_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3B, 0x1B, 0xC8
+#   elif defined (FIRMWARE_3_21)
+#       include "pl3/payload_trace_hypercalls_3_21.h"
+#       define default_payload payload_trace_hypercalls_3_21
+#       define default_payload_macro payload_trace_hypercalls_3_21_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x30
+#   elif defined (FIRMWARE_3_30)
+#       include "pl3/payload_trace_hypercalls_3_30.h"
+#       define default_payload payload_trace_hypercalls_3_30
+#       define default_payload_macro payload_trace_hypercalls_3_30_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x70
+#   endif
+//end Payload_Trace_HVC Payload
+//begin Payload_Trace_SC Payload... If you don't know what this is... you want Regular.
+#elif defined (Payload_Trace_SC)
+#   if defined (FIRMWARE_3_41)
+#       include "pl3/payload_trace_syscalls_3_41.h"
+#       define default_payload payload_trace_syscalls_3_41
+#       define default_payload_macro payload_trace_syscalls_3_41_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xee, 0x70
+#   elif defined (FIRMWARE_3_15)
+#       include "pl3/payload_trace_syscalls_3_15.h"
+#       define default_payload payload_trace_syscalls_3_15
+#       define default_payload_macro payload_trace_syscalls_3_15_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x30
+#   elif defined (FIRMWARE_3_10)
+#       include "pl3/payload_trace_syscalls_3_10.h"
+#       define default_payload payload_trace_syscalls_3_10
+#       define default_payload_macro payload_trace_syscalls_3_10_macro
+#       define SHELLCODE_ADDR_BASE  0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x30
+#   elif defined (FIRMWARE_3_01)
+#       include "pl3/payload_trace_syscalls_3_01.h"
+#       define default_payload payload_trace_syscalls_3_01
+#       define default_payload_macro payload_trace_syscalls_3_01_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3B, 0xFB, 0xC8
+#   elif defined (FIRMWARE_3_40)
+#       include "pl3/payload_trace_syscalls_3_40.h"
+#       define default_payload payload_trace_syscalls_3_40
+#       define default_payload_macro payload_trace_syscalls_3_40_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xee, 0x70
+#   elif defined (FIRMWARE_2_76)
+#       include "pl3/payload_trace_syscalls_2_76.h"
+#       define default_payload payload_trace_syscalls_2_76
+#       define default_payload_macro payload_trace_syscalls_2_76_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3B, 0x1B, 0xC8
+#   elif defined (FIRMWARE_3_21)
+#       include "pl3/payload_trace_syscalls_3_21.h"
+#       define default_payload payload_trace_syscalls_3_21
+#       define default_payload_macro payload_trace_syscalls_3_21_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x30
+#   elif defined (FIRMWARE_3_30)
+#       include "pl3/payload_trace_syscalls_3_30.h"
+#       define default_payload payload_trace_syscalls_3_30
+#       define default_payload_macro payload_trace_syscalls_3_30_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x70
+#   endif
+//end Payload_Trace_SC Payload
+//begin Payload_Trace_VUART Payload... If you don't know what this is... you want Regular.
+#elif defined (Payload_Trace_VUART)
+#   if defined (FIRMWARE_3_41)
+#       include "pl3/payload_trace_vuart_3_41.h"
+#       define default_payload payload_trace_vuart_3_41
+#       define default_payload_macro payload_trace_vuart_3_41_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xee, 0x70
+#   elif defined (FIRMWARE_3_15)
+#       include "pl3/payload_trace_vuart_3_15.h"
+#       define default_payload payload_trace_vuart_3_15
+#       define default_payload_macro payload_trace_vuart_3_15_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x30
+#   elif defined (FIRMWARE_3_10)
+#       include "pl3/payload_trace_vuart_3_10.h"
+#       define default_payload payload_trace_vuart_3_10
+#       define default_payload_macro payload_trace_vuart_3_10_macro
+#       define SHELLCODE_ADDR_BASE  0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x30
+#   elif defined (FIRMWARE_3_01)
+#       include "pl3/payload_trace_vuart_3_01.h"
+#       define default_payload payload_trace_vuart_3_01
+#       define default_payload_macro payload_trace_vuart_3_01_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3B, 0xFB, 0xC8
+#   elif defined (FIRMWARE_3_40)
+#       include "pl3/payload_trace_vuart_3_40.h"
+#       define default_payload payload_trace_vuart_3_40
+#       define default_payload_macro payload_trace_vuart_3_40_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xee, 0x70
+#   elif defined (FIRMWARE_2_76)
+#       include "pl3/payload_trace_vuart_2_76.h"
+#       define default_payload payload_trace_vuart_2_76
+#       define default_payload_macro payload_trace_vuart_2_76_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3B, 0x1B, 0xC8
+#   elif defined (FIRMWARE_3_21)
+#       include "pl3/payload_trace_vuart_3_21.h"
+#       define default_payload payload_trace_vuart_3_21
+#       define default_payload_macro payload_trace_vuart_3_21_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x30
+#   elif defined (FIRMWARE_3_30)
+#       include "pl3/payload_trace_vuart_3_30.h"
+#       define default_payload payload_trace_vuart_3_30
+#       define default_payload_macro payload_trace_vuart_3_30_macro
+#       define SHELLCODE_ADDR_BASE	0x80, 0x00, 0x00, 0x00, 0x00, 0x3d, 0xde, 0x70
+#   endif
+//end Payload_Trace_VUART Payload
+//add future playloads here
 #endif
 /* FIRMWARE_X_YZ */
 

--- a/firmware/usbstack/psgroove_descriptors.h
+++ b/firmware/usbstack/psgroove_descriptors.h
@@ -19,9 +19,9 @@
 #include "psgrooveFWSelection.h"
 
 #ifdef ROCKBOX_LITTLE_ENDIAN
-       #define LE16(x) (x)
+#     define LE16(x) (x)
 #else
-     #define LE16(x) ((( (x) & 0xFF) << 8) | (( (x) & 0xFF00) >> 8))
+#     define LE16(x) ((( (x) & 0xFF) << 8) | (( (x) & 0xFF00) >> 8))
 #endif
 
 #define MAGIC_NUMBER		'P', 'S', 'F', 'r', 'e', 'e', 'd', 'm'
@@ -93,7 +93,7 @@ const uint8_t HUB_Hub_Descriptor[] = {
 	0xff		// pwrctrlmask
 };
 
-const uint8_t jig_response[64] = {
+static const uint8_t jig_response[64] = {
 	#ifdef USE_JIG
 	SHELLCODE_PTR,
 	SHELLCODE_ADDRESS,
@@ -195,7 +195,7 @@ struct {
 		uint8_t unkData2;
 	} __attribute__ ((packed)) extra;
 } __attribute__ ((packed))
-port2_config_descriptor = {
+const port2_config_descriptor = {
 	{
 		.bLength			= USB_DT_CONFIG_SIZE,
 		.bDescriptorType	= USB_DT_CONFIG,

--- a/firmware/usbstack/psgroove_descriptors.h
+++ b/firmware/usbstack/psgroove_descriptors.h
@@ -28,7 +28,7 @@
 
 
 
-struct usb_device_descriptor HUB_Device_Descriptor = {
+const struct usb_device_descriptor HUB_Device_Descriptor = {
 	.bLength			= USB_DT_DEVICE_SIZE,
 	.bDescriptorType	= USB_DT_DEVICE,
 	.bcdUSB				= LE16(0x0200),
@@ -82,7 +82,7 @@ HUB_Config_Descriptor = {
 	}
 };
 
-uint8_t HUB_Hub_Descriptor[] = {
+const uint8_t HUB_Hub_Descriptor[] = {
 	0x09,		// size
 	0x29,		// type: hub
 	0x06,		// num ports
@@ -93,7 +93,7 @@ uint8_t HUB_Hub_Descriptor[] = {
 	0xff		// pwrctrlmask
 };
 
-uint8_t jig_response[64] = {
+const uint8_t jig_response[64] = {
 	#ifdef USE_JIG
 	SHELLCODE_PTR,
 	SHELLCODE_ADDRESS,
@@ -106,7 +106,7 @@ uint8_t jig_response[64] = {
 	#endif
 };
 
-struct usb_device_descriptor port1_device_descriptor = {
+const struct usb_device_descriptor port1_device_descriptor = {
 	.bLength			= USB_DT_DEVICE_SIZE,
 	.bDescriptorType	= USB_DT_DEVICE,
 	.bcdUSB				= LE16(0x0200),
@@ -168,7 +168,7 @@ port1_config_descriptor = {
 	}
 };
 
-struct usb_device_descriptor port2_device_descriptor = {
+const struct usb_device_descriptor port2_device_descriptor = {
 	.bLength			= USB_DT_DEVICE_SIZE,
 	.bDescriptorType	= USB_DT_DEVICE,
 	.bcdUSB				= LE16(0x0200),
@@ -225,7 +225,7 @@ port2_config_descriptor = {
 	}
 };
 
-struct usb_device_descriptor port3_device_descriptor = {
+const struct usb_device_descriptor port3_device_descriptor = {
 	.bLength			= USB_DT_DEVICE_SIZE,
 	.bDescriptorType	= USB_DT_DEVICE,
 	.bcdUSB				= LE16(0x0200),
@@ -242,7 +242,7 @@ struct usb_device_descriptor port3_device_descriptor = {
 	.bNumConfigurations	= 0x02
 };
 
-struct usb_config_descriptor port3_config_descriptor = {
+const struct usb_config_descriptor port3_config_descriptor = {
 	.bLength			= USB_DT_CONFIG_SIZE,
 	.bDescriptorType	= USB_DT_CONFIG,
 	.wTotalLength		= LE16(0xa4d),
@@ -253,7 +253,7 @@ struct usb_config_descriptor port3_config_descriptor = {
 	.bMaxPower			= 1
 };
 
-struct usb_interface_descriptor port3_padding = {
+const struct usb_interface_descriptor port3_padding = {
 	.bLength			= USB_DT_INTERFACE_SIZE,
 	.bDescriptorType	= USB_DT_INTERFACE,
 	.bInterfaceNumber	= 0,
@@ -265,7 +265,7 @@ struct usb_interface_descriptor port3_padding = {
 	.iInterface			= 0
 };
 
-struct usb_device_descriptor port4_device_descriptor = {
+const struct usb_device_descriptor port4_device_descriptor = {
 	.bLength			= USB_DT_DEVICE_SIZE,
 	.bDescriptorType	= USB_DT_DEVICE,
 	.bcdUSB				= LE16(0x0200),
@@ -286,7 +286,7 @@ struct {
 	struct usb_config_descriptor	config;
 	struct usb_interface_descriptor	interface;
 } __attribute__ ((packed))
-port4_config_descriptor_1 = {
+const port4_config_descriptor_1 = {
 	{
 		.bLength			= USB_DT_CONFIG_SIZE,
 		.bDescriptorType	= USB_DT_CONFIG,
@@ -348,7 +348,7 @@ struct {
 		uint8_t data[3][8];
 	} __attribute__ ((packed)) extra;
 } __attribute__ ((packed))
-port4_config_descriptor_3 = {
+const port4_config_descriptor_3 = {
 	{
 		.bLength			= USB_DT_CONFIG_SIZE,
 		.bDescriptorType	= USB_DT_CONFIG,
@@ -380,7 +380,7 @@ port4_config_descriptor_3 = {
 	}
 };
 
-struct usb_device_descriptor port5_device_descriptor = {
+const struct usb_device_descriptor port5_device_descriptor = {
 	.bLength			= USB_DT_DEVICE_SIZE,
 	.bDescriptorType	= USB_DT_DEVICE,
 	.bcdUSB				= LE16(0x0200),
@@ -443,7 +443,7 @@ port5_config_descriptor = {
 	}
 };
 
-struct usb_device_descriptor final_device_descriptor = {
+const struct usb_device_descriptor final_device_descriptor = {
 	.bLength			= USB_DT_DEVICE_SIZE,
 	.bDescriptorType	= USB_DT_DEVICE,
 	.bcdUSB				= LE16(0x0200),
@@ -454,7 +454,7 @@ struct usb_device_descriptor final_device_descriptor = {
 	.idVendor			= LE16(0xAAAA),
 	.idProduct			= LE16(0x3713), // pl3 no longer cares about this value
 	.bcdDevice			= LE16(0x0000),
-	.iManufacturer		= 0x0,
+	.iManufacturer		= 0x00,
 	.iProduct			= 0x00,
 	.iSerialNumber		= 0x00,
 	.bNumConfigurations	= 0x01
@@ -464,7 +464,7 @@ struct {
 	struct usb_config_descriptor	config;
 	struct usb_interface_descriptor	interface;
 } __attribute__ ((packed))
-final_config_descriptor = {
+const final_config_descriptor = {
 	{
 		.bLength			= USB_DT_CONFIG_SIZE,
 		.bDescriptorType	= USB_DT_CONFIG,


### PR DESCRIPTION
Added support for easy compilation of DEV, NUS, TRACE ALL SC, TRACE SC, TRACE HV, TRACE VUART, and DUMP ELF PL3 payloads.

-Added Config.h to firmware/usbstack to remove configuration dependancy on pl3's config.h.
---Added all current firmware definitions to rockbox-psgroove's specific config.h (Step 1. in the config)
---Added payload selection between Regular, NUS, DEV, and all trace payloads to allow rockbox-psgroove to act like a development jig and dongle in config.h.
-Added psgrooveFWSelection.h and moved firmware specific #ifdef's to it from psgroove_descriptors.h.as well as added defintions for the new PL3 "DEV" payloads.
-Readded removed const definitions to my payload that were inadvertently removed in the previous pull request.
